### PR TITLE
Add (dummy) search bar behavior

### DIFF
--- a/services/frontend/src/App.js
+++ b/services/frontend/src/App.js
@@ -3,37 +3,35 @@ import SearchBar from "./components/SearchBar";
 import { useState } from "react";
 
 export const App = () => {
-
   const defaultCity = {
-      city: "San Francisco",
-      state: "CA"
-  }
-  
-  const [mainCity, setMainCity] = useState(defaultCity)
+    city: "San Francisco",
+    state: "CA",
+  };
+
+  const [mainCity, setMainCity] = useState(defaultCity);
   const [suggestedCities, setSuggestedCities] = useState([
-      {city: "Chicago", state: "IL"},
-      {city: "Oakland", state: "CA"},
-      {city: "New York", state: "NY"},
-  ])
+    { city: "Chicago", state: "IL" },
+    { city: "Oakland", state: "CA" },
+    { city: "New York", state: "NY" },
+  ]);
 
   const updateMainCity = (newLocation) => {
-      if (newLocation !== mainCity) {
-          // Prepend prev. mainCity to top of suggested cities array
-          setSuggestedCities([mainCity, ...suggestedCities]);
-      }
-      // React is smart enough to determine if the new content differs from the old.
-      // So we can do this outside the if statement.
-      setMainCity({city: newLocation.city, state: newLocation.state});
-  }
+    if (newLocation !== mainCity) {
+      // Prepend prev. mainCity to top of suggested cities array
+      setSuggestedCities([mainCity, ...suggestedCities]);
+    }
+    // React is smart enough to determine if the new content differs from the old.
+    // So we can do this outside the if statement.
+    setMainCity({ city: newLocation.city, state: newLocation.state });
+  };
 
   return (
     <div className="flex flex-col">
-      <SearchBar handleUserSearch={updateMainCity}/>
-      <WeatherForecast
-        locationData={mainCity}
-        defaultExpanded={true}
-      />
-      {suggestedCities.slice(0, 3).map((suggestedCity, index) => {return <WeatherForecast locationData={suggestedCity} key={index}/>})}
+      <SearchBar handleUserSearch={updateMainCity} />
+      <WeatherForecast locationData={mainCity} defaultExpanded={true} />
+      {suggestedCities.slice(0, 3).map((suggestedCity, index) => {
+        return <WeatherForecast locationData={suggestedCity} key={index} />;
+      })}
     </div>
   );
 };

--- a/services/frontend/src/App.js
+++ b/services/frontend/src/App.js
@@ -16,7 +16,10 @@ export const App = () => {
   ]);
 
   const updateMainCity = (newLocation) => {
-    if (newLocation !== mainCity) {
+    if (
+      newLocation.city !== mainCity.city &&
+      newLocation.state !== mainCity.state
+    ) {
       // Prepend prev. mainCity to top of suggested cities array
       setSuggestedCities([mainCity, ...suggestedCities]);
     }

--- a/services/frontend/src/App.js
+++ b/services/frontend/src/App.js
@@ -17,7 +17,7 @@ export const App = () => {
 
   const updateMainCity = (newLocation) => {
     if (
-      newLocation.city !== mainCity.city &&
+      newLocation.city !== mainCity.city ||
       newLocation.state !== mainCity.state
     ) {
       // Prepend prev. mainCity to top of suggested cities array

--- a/services/frontend/src/App.js
+++ b/services/frontend/src/App.js
@@ -1,16 +1,39 @@
 import WeatherForecast from "./components/WeatherForecast";
 import SearchBar from "./components/SearchBar";
+import { useState } from "react";
 
 export const App = () => {
+
+  const defaultCity = {
+      city: "San Francisco",
+      state: "CA"
+  }
+  
+  const [mainCity, setMainCity] = useState(defaultCity)
+  const [suggestedCities, setSuggestedCities] = useState([
+      {city: "Chicago", state: "IL"},
+      {city: "Oakland", state: "CA"},
+      {city: "New York", state: "NY"},
+  ])
+
+  const updateMainCity = (newLocation) => {
+      if (newLocation !== mainCity) {
+          // Prepend prev. mainCity to top of suggested cities array
+          setSuggestedCities([mainCity, ...suggestedCities]);
+      }
+      // React is smart enough to determine if the new content differs from the old.
+      // So we can do this outside the if statement.
+      setMainCity({city: newLocation.city, state: newLocation.state});
+  }
+
   return (
     <div className="flex flex-col">
-      <SearchBar />
+      <SearchBar handleUserSearch={updateMainCity}/>
       <WeatherForecast
-        locationData={{ city: "San Francisco", state: "CA" }}
+        locationData={mainCity}
         defaultExpanded={true}
       />
-      <WeatherForecast locationData={{ city: "Chicago", state: "IL" }} />
-      <WeatherForecast locationData={{ city: "Oakland", state: "CA" }} />
+      {suggestedCities.slice(0, 3).map((suggestedCity, index) => {return <WeatherForecast locationData={suggestedCity} key={index}/>})}
     </div>
   );
 };

--- a/services/frontend/src/App.js
+++ b/services/frontend/src/App.js
@@ -21,7 +21,7 @@ export const App = () => {
       newLocation.state !== mainCity.state
     ) {
       // Prepend prev. mainCity to top of suggested cities array
-      setSuggestedCities([mainCity, ...suggestedCities]);
+      setSuggestedCities([mainCity, ...suggestedCities.slice(1, 3)]);
     }
     // React is smart enough to determine if the new content differs from the old.
     // So we can do this outside the if statement.
@@ -32,7 +32,7 @@ export const App = () => {
     <div className="flex flex-col">
       <SearchBar handleUserSearch={updateMainCity} />
       <WeatherForecast locationData={mainCity} defaultExpanded={true} />
-      {suggestedCities.slice(0, 3).map((suggestedCity, index) => {
+      {suggestedCities.map((suggestedCity, index) => {
         return <WeatherForecast locationData={suggestedCity} key={index} />;
       })}
     </div>

--- a/services/frontend/src/components/SearchBar.js
+++ b/services/frontend/src/components/SearchBar.js
@@ -1,38 +1,39 @@
 import { useState } from "react";
-import { PropTypes } from 'prop-types';
+import { PropTypes } from "prop-types";
 
-const SearchBar = ({handleUserSearch}) => {
-
+const SearchBar = ({ handleUserSearch }) => {
   const [userInput, setUserInput] = useState("");
 
   const handleUserInputChange = (event) => {
-      setUserInput(event.target.value);
+    setUserInput(event.target.value);
   };
 
   const handleFormSubmit = (event) => {
-      event.preventDefault();
-      try {
-          const parsedLocation = validateFormData(userInput);
-          handleUserSearch(parsedLocation);
-      } catch (e) {
-          alert("Search input could not be pased. Please use `City, State` format.");
-      }
-      setUserInput('');
+    event.preventDefault();
+    try {
+      const parsedLocation = validateFormData(userInput);
+      handleUserSearch(parsedLocation);
+    } catch (e) {
+      alert(
+        "Search input could not be pased. Please use `City, State` format."
+      );
+    }
+    setUserInput("");
   };
 
   const validateFormData = (stringData) => {
-      // This function will be replaced by backend parsing
-      let splitString = stringData.split(",");
-      console.log(splitString);
-      if (splitString.length !== 2) {
-          throw new Error(`Unable to parse input ${stringData}`);
-      }
-      const location = {
-          city: splitString[0].trim(),
-          state: splitString[1].trim(),
-      };
-      return location;
-  }
+    // This function will be replaced by backend parsing
+    let splitString = stringData.split(",");
+    console.log(splitString);
+    if (splitString.length !== 2) {
+      throw new Error(`Unable to parse input ${stringData}`);
+    }
+    const location = {
+      city: splitString[0].trim(),
+      state: splitString[1].trim(),
+    };
+    return location;
+  };
 
   return (
     <div className="md:w-1/2 mx-auto my-5 rounded-xl shadow-md text-gray-700 text-center text-xl p-4 bg-gray-200">
@@ -53,7 +54,7 @@ const SearchBar = ({handleUserSearch}) => {
 };
 
 SearchBar.propTypes = {
-    handleUserSearch: PropTypes.func,
+  handleUserSearch: PropTypes.func,
 };
 
 export default SearchBar;

--- a/services/frontend/src/components/SearchBar.js
+++ b/services/frontend/src/components/SearchBar.js
@@ -15,9 +15,10 @@ const SearchBar = ({ handleUserSearch }) => {
       handleUserSearch(parsedLocation);
     } catch (e) {
       alert(
-        "Search input could not be pased. Please use `City, State` format."
+        "Search input could not be parsed. Please use `City, State` format."
       );
     }
+    // Reset input
     setUserInput("");
   };
 

--- a/services/frontend/src/components/SearchBar.js
+++ b/services/frontend/src/components/SearchBar.js
@@ -1,18 +1,59 @@
-const SearchBar = () => {
+import { useState } from "react";
+import { PropTypes } from 'prop-types';
+
+const SearchBar = ({handleUserSearch}) => {
+
+  const [userInput, setUserInput] = useState("");
+
+  const handleUserInputChange = (event) => {
+      setUserInput(event.target.value);
+  };
+
+  const handleFormSubmit = (event) => {
+      event.preventDefault();
+      try {
+          const parsedLocation = validateFormData(userInput);
+          handleUserSearch(parsedLocation);
+      } catch (e) {
+          alert("Search input could not be pased. Please use `City, State` format.");
+      }
+      setUserInput('');
+  };
+
+  const validateFormData = (stringData) => {
+      // This function will be replaced by backend parsing
+      let splitString = stringData.split(",");
+      console.log(splitString);
+      if (splitString.length !== 2) {
+          throw new Error(`Unable to parse input ${stringData}`);
+      }
+      const location = {
+          city: splitString[0].trim(),
+          state: splitString[1].trim(),
+      };
+      return location;
+  }
+
   return (
     <div className="md:w-1/2 mx-auto my-5 rounded-xl shadow-md text-gray-700 text-center text-xl p-4 bg-gray-200">
-      <form>
+      <form onSubmit={handleFormSubmit}>
         <div>
           <input
             className="md:w-full border-2 border-gray-200 w-full py-2 px-4 text-gray-700"
             id="search-location"
             type="text"
             placeholder="Enter a location"
+            value={userInput}
+            onChange={handleUserInputChange}
           />
         </div>
       </form>
     </div>
   );
+};
+
+SearchBar.propTypes = {
+    handleUserSearch: PropTypes.func,
 };
 
 export default SearchBar;


### PR DESCRIPTION
This PR adds actual functionality to the search bar. To accomplish this added stateful behavior to the `App` component.

`App` now has two states:

1. `mainCity`: First item under the search bar, expanded by default
2. `suggestedCities`: A list of additional cities that appear below the mainCity, collapsed by default

The `updateMainCity` function allows the SearchBar component to set a new mainCity. It places the old mainCity at the top of the suggestedCities list.

`SearchBar` now accepts a function that `App` passes down to update the `mainCity`. When the form is submitted a helper function attempts to parse out the city/state data (ideally this will be handled on the backend) and passes the value up to App.

How to test:
Run the frontend and try:
- Entering a new `City, State` in the search bar.
  - A new forecast widget should appear.
  - The old forecast should move down into the collapsed suggestions list
  - The suggested cities list should never exceed 3 items.
- Re-enter the same value as the current primary forecast (`San Francisco, CA` by default)
  - Nothing should happen (the app detects no change is necessary)
- Enter a value that's not comma separated
  - You should get a browser alert telling you it's an invalid format