### PR TITLE
Add dummy backend data fetching

### DIFF
--- a/services/backend/api/api.py
+++ b/services/backend/api/api.py
@@ -1,4 +1,8 @@
 from fastapi import FastAPI
+from .models import Condition, Forecast
+from typing import Dict, List, Optional
+from datetime import datetime, timedelta
+import random
 
 app = FastAPI()
 
@@ -6,3 +10,20 @@ app = FastAPI()
 @app.get("/")
 async def get_root():
     return {"data": "I am a WeatherApp"}
+
+
+@app.get("/forecast/{location}", response_model=Dict[str, List[Forecast]])
+async def get_forecast_by_location(
+    location: str, start_date: Optional[datetime] = None, days: int = 5
+):
+    if not start_date:
+        start_date = datetime.now().date()
+    forecasts = []
+    for delta in range(days):
+        forecast_date = start_date + timedelta(days=delta)
+        # Just get a random condition and temp
+        condition = random.choice(list(Condition))
+        temp = round(random.uniform(23, 105), 1)
+        forecast = Forecast(date=forecast_date, condition=condition, temp=temp)
+        forecasts.append(forecast)
+    return {location: forecasts}

--- a/services/backend/api/api.py
+++ b/services/backend/api/api.py
@@ -1,10 +1,21 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from .models import Condition, Forecast
 from typing import Dict, List, Optional
 from datetime import datetime, timedelta
 import random
 
 app = FastAPI()
+
+origins = ["http://localhost", "http://localhost:3000"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/")

--- a/services/backend/api/api.py
+++ b/services/backend/api/api.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .models import Condition, Forecast
-from typing import Dict, List, Optional
+from typing import List, Optional
 from datetime import datetime, timedelta
 import random
 
@@ -23,7 +23,7 @@ async def get_root():
     return {"data": "I am a WeatherApp"}
 
 
-@app.get("/forecast/{location}", response_model=Dict[str, List[Forecast]])
+@app.get("/forecast/{location}", response_model=List[Forecast])
 async def get_forecast_by_location(
     location: str, start_date: Optional[datetime] = None, days: int = 5
 ):
@@ -37,4 +37,4 @@ async def get_forecast_by_location(
         temp = round(random.uniform(23, 105), 1)
         forecast = Forecast(date=forecast_date, condition=condition, temp=temp)
         forecasts.append(forecast)
-    return {location: forecasts}
+    return forecasts

--- a/services/backend/api/models.py
+++ b/services/backend/api/models.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from datetime import date
+from enum import Enum
+
+
+class Condition(str, Enum):
+    sunny = "sunny"
+    cloudy = "cloudy"
+    partial_cloudy = "partial-cloudy"
+    partial_sunny = "partial-sunny"
+    windy = "windy"
+    lightning = "lightning"
+    snow = "snow"
+    rain = "rain"
+    light_right = "light-rain"
+    heavy_rain = "heavy-rain"
+
+
+class Forecast(BaseModel):
+    date: date
+    condition: Condition
+    temp: float
+
+    class Config:
+        use_enum_values = True

--- a/services/backend/tests/test_api.py
+++ b/services/backend/tests/test_api.py
@@ -17,5 +17,4 @@ def test_forecast():
         response.status_code == 200
     ), f"Expected response 200, got {response.status_code}: {response.reason}."
     data = response.json()
-    forecast = data[test_location]
-    assert len(forecast) == days
+    assert len(data) == days

--- a/services/backend/tests/test_api.py
+++ b/services/backend/tests/test_api.py
@@ -17,6 +17,5 @@ def test_forecast():
         response.status_code == 200
     ), f"Expected response 200, got {response.status_code}: {response.reason}."
     data = response.json()
-    assert test_location in data
     forecast = data[test_location]
     assert len(forecast) == days

--- a/services/backend/tests/test_api.py
+++ b/services/backend/tests/test_api.py
@@ -7,3 +7,16 @@ test_app = TestClient(app)
 def test_root():
     response = test_app.get("/")
     assert response.status_code == 200
+
+
+def test_forecast():
+    test_location = "San Francisco, CA"
+    days = 10
+    response = test_app.get(f"/forecast/{test_location}?days={days}")
+    assert (
+        response.status_code == 200
+    ), f"Expected response 200, got {response.status_code}: {response.reason}."
+    data = response.json()
+    assert test_location in data
+    forecast = data[test_location]
+    assert len(forecast) == days

--- a/services/frontend/src/components/WeatherForecast.js
+++ b/services/frontend/src/components/WeatherForecast.js
@@ -10,7 +10,7 @@ export const WeatherForecast = ({ locationData, defaultExpanded }) => {
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
-    fetch(`http://localhost:8000/forecast/foo`)
+    fetch(`http://localhost:8000/forecast/${locationData.city}, ${locationData.state}`)
     .then(res => res.json())
     .then(
       (result) => {

--- a/services/frontend/src/components/WeatherForecast.js
+++ b/services/frontend/src/components/WeatherForecast.js
@@ -4,25 +4,26 @@ import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 
 export const WeatherForecast = ({ locationData, defaultExpanded }) => {
-
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const [weatherData, setWeatherData] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
-    fetch(`http://localhost:8000/forecast/${locationData.city}, ${locationData.state}`)
-    .then(res => res.json())
-    .then(
-      (result) => {
-        // console.log(result);
-        setWeatherData(result);
-        setIsLoaded(true);
-      },
-      (error) => {
-        console.log(error);
-        // TODO: Add isError state handling
-      }
+    fetch(
+      `http://localhost:8000/forecast/${locationData.city}, ${locationData.state}`
     )
+      .then((res) => res.json())
+      .then(
+        (result) => {
+          // console.log(result);
+          setWeatherData(result);
+          setIsLoaded(true);
+        },
+        (error) => {
+          console.log(error);
+          // TODO: Add isError state handling
+        }
+      );
   }, [locationData]);
 
   const toggleExpanded = () => {
@@ -37,7 +38,11 @@ export const WeatherForecast = ({ locationData, defaultExpanded }) => {
           onClick={toggleExpanded}
         >
           <Header city={locationData.city} state={locationData.state} />
-          {isLoaded ? <WeatherWidgetContainer weatherObjArray={weatherData} /> : <p>"Loading..."</p>}
+          {isLoaded ? (
+            <WeatherWidgetContainer weatherObjArray={weatherData} />
+          ) : (
+            <p>"Loading..."</p>
+          )}
         </div>
       ) : (
         <div

--- a/services/frontend/src/components/WeatherForecast.js
+++ b/services/frontend/src/components/WeatherForecast.js
@@ -1,34 +1,29 @@
 import WeatherWidgetContainer from "./WeatherWidgetContainer";
 import Header from "./Header";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 
 export const WeatherForecast = ({ locationData, defaultExpanded }) => {
-  // Placeholder weather data
-  const weatherData = [
-    {
-      temp: 51,
-      cond: "cloudy",
-    },
-    {
-      temp: 48,
-      cond: "rain",
-    },
-    {
-      temp: 58,
-      cond: "windy",
-    },
-    {
-      temp: 62,
-      cond: "partial-cloudy",
-    },
-    {
-      temp: 71,
-      cond: "sunny",
-    },
-  ];
 
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const [weatherData, setWeatherData] = useState(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    fetch(`http://localhost:8000/forecast/foo`)
+    .then(res => res.json())
+    .then(
+      (result) => {
+        // console.log(result);
+        setWeatherData(result);
+        setIsLoaded(true);
+      },
+      (error) => {
+        console.log(error);
+        // TODO: Add isError state handling
+      }
+    )
+  }, [locationData]);
 
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded);
@@ -42,7 +37,7 @@ export const WeatherForecast = ({ locationData, defaultExpanded }) => {
           onClick={toggleExpanded}
         >
           <Header city={locationData.city} state={locationData.state} />
-          <WeatherWidgetContainer weatherObjArray={weatherData} />
+          {isLoaded ? <WeatherWidgetContainer weatherObjArray={weatherData} /> : <p>"Loading..."</p>}
         </div>
       ) : (
         <div

--- a/services/frontend/src/components/WeatherWidget.js
+++ b/services/frontend/src/components/WeatherWidget.js
@@ -12,7 +12,7 @@ import {
   faSlash,
 } from "@fortawesome/free-solid-svg-icons";
 
-const WeatherWidget = ({ temp, cond }) => {
+const WeatherWidget = ({ temp, condition }) => {
   const getIconFromString = (conditionString) => {
     let returnVal;
     switch (conditionString) {
@@ -53,7 +53,7 @@ const WeatherWidget = ({ temp, cond }) => {
     <div className="px-5 text-2xl md:text-6xl">
       <div>
         <h1>
-          <FontAwesomeIcon icon={getIconFromString(cond)} />
+          <FontAwesomeIcon icon={getIconFromString(condition)} />
         </h1>
       </div>
       <div className="text-2xl md:text-4xl">
@@ -67,7 +67,7 @@ const WeatherWidget = ({ temp, cond }) => {
 
 WeatherWidget.propTypes = {
   temp: PropTypes.number,
-  cond: PropTypes.string,
+  condition: PropTypes.string,
 };
 
 export default WeatherWidget;

--- a/services/frontend/src/components/WeatherWidgetContainer.js
+++ b/services/frontend/src/components/WeatherWidgetContainer.js
@@ -1,18 +1,11 @@
 import PropTypes from "prop-types";
 import WeatherWidget from "./WeatherWidget";
 
-const WeatherWidgetContainer = ({ weatherObjArray, widgetCount }) => {
+const WeatherWidgetContainer = ({ weatherObjArray }) => {
   const createWeatherWidgets = (objArray) => {
     const widgetArray = [];
-    for (let index = 0; index < widgetCount; index++) {
-      let obj = objArray[index];
-      if (!obj) {
-        console.log(`Object ${index} was missing!`);
-        obj = { temp: null, cond: null };
-      }
-      const widget = (
-        <WeatherWidget key={index} temp={obj.temp} cond={obj.cond} />
-      );
+    for (const [index, obj] of objArray.entries()) {
+      const widget = <WeatherWidget key={index} temp={obj.temp} condition={obj.condition} />;
       widgetArray.push(widget);
     }
     return widgetArray;
@@ -29,10 +22,9 @@ WeatherWidgetContainer.propTypes = {
   weatherObjArray: PropTypes.arrayOf(
     PropTypes.shape({
       temp: PropTypes.number,
-      cond: PropTypes.string,
+      condition: PropTypes.string,
     })
   ),
-  widgetCount: PropTypes.number,
 };
 
 WeatherWidgetContainer.defaultProps = {

--- a/services/frontend/src/components/WeatherWidgetContainer.js
+++ b/services/frontend/src/components/WeatherWidgetContainer.js
@@ -5,7 +5,9 @@ const WeatherWidgetContainer = ({ weatherObjArray }) => {
   const createWeatherWidgets = (objArray) => {
     const widgetArray = [];
     for (const [index, obj] of objArray.entries()) {
-      const widget = <WeatherWidget key={index} temp={obj.temp} condition={obj.condition} />;
+      const widget = (
+        <WeatherWidget key={index} temp={obj.temp} condition={obj.condition} />
+      );
       widgetArray.push(widget);
     }
     return widgetArray;


### PR DESCRIPTION
# Overview
This PR replaces the placeholder weather forecast data in the frontend with actual data fetching from the backend.

To accomplish this I added a `/forecast/` endpoint to the backend. Currently it just randomly generates a list of conditions and temperatures regardless of what location is queried.

The frontend static data has been replaced with an async `fetch` call in `WeatherForecast.js`. This also involved adding additional states to store the data and the loading status.

# How to Test
* Spin up the docker containers
* Navigate to `localhost:8000/docs` and test out the new endpoint
* Navigate to `localhost:3000` and observe how weather data is dynamically populated
* [Optional] Kill only the backend service and observe how the weather data never populates and the widgets are stuck in a "loading" state.
<img width="758" alt="Screen Shot 2021-10-05 at 4 22 02 PM" src="https://user-images.githubusercontent.com/8881836/136116602-fd847bf6-2c95-479e-a774-4f4d07e63768.png">
<img width="506" alt="Screen Shot 2021-10-05 at 4 22 24 PM" src="https://user-images.githubusercontent.com/8881836/136116605-c9d1f9f1-f6bb-424c-bfbc-6f5efd333d8c.png">

